### PR TITLE
Unname tidy-selection to avoid looking like a rename

### DIFF
--- a/R/metaconfoundr.R
+++ b/R/metaconfoundr.R
@@ -130,6 +130,7 @@ mc_wider <- function(
       -dplyr::all_of(is_confounder)
     ) %>%
       tidyselect::vars_select(dplyr::all_of(study))
+    columns <- unname(columns)
 
     .df <- tidyr::pivot_longer(
       .df,


### PR DESCRIPTION
Hi @malcolmbarrett,

We ran revdeps for the upcoming release of tidyr 1.3.0 and your package came up.

In dev tidyr we have becoming slightly stricter and now error if you try to provide a named tidy-selection to functions like `pivot_longer()`. In the best case, this previously had no effect even though it "looked" like renaming was being requested. In the worst cases, it actually broke some tidyr functions.

We plan to release tidyr 1.3.0 on January 23rd.

This patch is backwards compatible with CRAN tidyr. If you could go ahead and release a version of your package to CRAN with this patch, then it would help us out a lot when we release tidyr. Thanks!